### PR TITLE
Define CODEX_API_KEY env variable

### DIFF
--- a/codex_jira_test_gen.py
+++ b/codex_jira_test_gen.py
@@ -19,6 +19,7 @@ TEST_ISSUETYPE_NAME = os.getenv("TEST_ISSUETYPE_NAME","Test")
 LINK_TYPE_NAME       = os.getenv("LINK_TYPE_NAME","Tests")
 
 CODEX_BASE = os.getenv("CODEX_BASE")
+CODEX_API_KEY = os.getenv("CODEX_API_KEY")
 
 
 def jira_headers():


### PR DESCRIPTION
## Summary
- load CODEX_API_KEY from environment so optional CodeX integration works without NameError

## Testing
- python -m py_compile codex_jira_test_gen.py

------
https://chatgpt.com/codex/tasks/task_b_68e3b1581a348327a9e3236eb2c23d35