### PR TITLE
Add offline execution flow for Jira test generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # CodeXPOCRepo
-CodeX POC repository Creation 
+
+CodeX POC repository Creation
+
+## Offline test generation
+
+You can execute the Jira test generation utility without network access by
+providing an exported issue payload:
+
+```bash
+python codex_jira_test_gen.py --jira-key DEMO-1 --issue-json sample_issue.json --mode repo
+```
+
+The `sample_issue.json` file in this repository illustrates the expected
+structure and will generate Markdown and Gherkin artifacts under
+`tests/generated/DEMO-1/`.

--- a/sample_issue.json
+++ b/sample_issue.json
@@ -1,0 +1,12 @@
+{
+  "key": "DEMO-1",
+  "fields": {
+    "summary": "User can reset password via email link",
+    "description": "As a user I want to reset my password so that I can regain access.",
+    "labels": ["poc"],
+    "priority": {"name": "Medium"},
+    "project": {"key": "DEMO"},
+    "status": {"name": "To Do"},
+    "customfield_10059": "Given the user has requested a reset email, when the link is used the password can be changed.\n- Email link expires after one use."
+  }
+}

--- a/tests/generated/DEMO-1/DEMO-1.feature
+++ b/tests/generated/DEMO-1/DEMO-1.feature
@@ -1,0 +1,13 @@
+Feature: Auto tests
+
+Scenario: User can reset password via email link – AC1
+  Given As per story
+  When Given the user has requested a reset email, when the link is used the password can be changed.
+  Then Acceptance criterion satisfied
+
+
+Scenario: User can reset password via email link – AC2
+  Given As per story
+  When Email link expires after one use.
+  Then Acceptance criterion satisfied
+

--- a/tests/generated/DEMO-1/TC_01.md
+++ b/tests/generated/DEMO-1/TC_01.md
@@ -1,0 +1,14 @@
+# User can reset password via email link – AC1
+
+**Preconditions**  
+
+As per story
+
+## Steps
+
+1. Given the user has requested a reset email, when the link is used the password can be changed.
+
+## Expected
+
+- Acceptance criterion satisfied
+

--- a/tests/generated/DEMO-1/TC_02.md
+++ b/tests/generated/DEMO-1/TC_02.md
@@ -1,0 +1,14 @@
+# User can reset password via email link – AC2
+
+**Preconditions**  
+
+As per story
+
+## Steps
+
+1. Email link expires after one use.
+
+## Expected
+
+- Acceptance criterion satisfied
+


### PR DESCRIPTION
## Summary
- add a JSON-based issue loading option so the generator can run without Jira credentials
- avoid auto-installing `requests` and skip Jira updates when the library is unavailable
- document the offline workflow and include a sample issue with generated artifacts

## Testing
- python codex_jira_test_gen.py --jira-key DEMO-1 --issue-json sample_issue.json --mode repo

------
https://chatgpt.com/codex/tasks/task_b_68e3b29eabbc832798872b92108442dc