### PR TITLE
Secure Jira script configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env and replace the placeholder values with your Jira credentials.
+# Never commit the real credentials to version control.
+JIRA_BASE_URL="https://your-domain.atlassian.net"
+JIRA_EMAIL="you@example.com"
+JIRA_API_TOKEN="your-api-token"
+JIRA_PROJECT_KEY="SCRUM"
+STORY_KEY="SCRUM-1"
+TEST_ISSUE_TYPE="Test"
+ISSUE_LINK_TYPE="Relates"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 CodeXPOCRepo
-CodeX POC repository Creation
+============
+
+Proof-of-concept utilities for automating Jira test creation.
+
+## Usage
+
+1. Copy the example environment file and populate it with your Jira details:
+
+   ```bash
+   cp .env.example .env
+   # edit .env with your Jira base URL, email, API token, etc.
+   ```
+
+2. Run the helper script to execute `create_test_from_story.py` with the configured environment:
+
+   ```bash
+   ./scriptrunner.sh
+   ```
+
+The script will refuse to run unless all required environment variables are provided, helping prevent accidental commits of real credentials.

--- a/create_test_from_story.py
+++ b/create_test_from_story.py
@@ -15,7 +15,16 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-log.info("JIRA BASE=%s JIRA Email=%s JIRA Token=%s Project_key=%s Story_Key=%s Test_type=%s",JIRA_BASE,JIRA_EMAIL,JIRA_TOKEN,PROJECT_KEY,STORY_KEY,TEST_TYPE)
+masked_token = f"{JIRA_TOKEN[:4]}…" if len(JIRA_TOKEN) > 4 else "***"
+log.info(
+    "JIRA BASE=%s JIRA Email=%s JIRA Token=%s Project_key=%s Story_Key=%s Test_type=%s",
+    JIRA_BASE,
+    JIRA_EMAIL,
+    masked_token,
+    PROJECT_KEY,
+    STORY_KEY,
+    TEST_TYPE,
+)
 
 auth = (JIRA_EMAIL, JIRA_TOKEN)
 headers = {"Accept": "application/json", "Content-Type": "application/json"}

--- a/scriptrunner.sh
+++ b/scriptrunner.sh
@@ -1,12 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
 
-export JIRA_BASE_URL="https://altimetrikjiraaccess.atlassian.net"
-export JIRA_EMAIL="altimetrikjiraaccess@gmail.com"
-export JIRA_API_TOKEN="ATATT3xFfGF0IxFZXndLW-YYpfvdofTzX-7t4mqpCsJA5Kysaw5eTrJOU5_a2lxFDC8pP0KFagitT5HwNuWzkYaRiEjd44RFgRBt-mxWGyyArw-VxVXd4uLbtIjLNYrUNylCplAkcD83GN-4Lo4ePH2JyU5NWd_-oVi1vwN7MU3k-1wSu-X4tHQ=D0C300D1"
-export JIRA_PROJECT_KEY="SCRUM"
-export STORY_KEY="SCRUM-1"
-export TEST_ISSUE_TYPE="Test"           # or "Test Case" (Zephyr), etc.
-export ISSUE_LINK_TYPE="Relates"        # or "Tests", "Blocks", depending on your scheme
+if [ -f ".env" ]; then
+  # Load environment variables from local .env file without exporting secrets to the repo.
+  set -a
+  source .env
+  set +a
+fi
 
+: "${JIRA_BASE_URL:?Set JIRA_BASE_URL in the environment or .env file}"
+: "${JIRA_EMAIL:?Set JIRA_EMAIL in the environment or .env file}"
+: "${JIRA_API_TOKEN:?Set JIRA_API_TOKEN in the environment or .env file}"
+: "${JIRA_PROJECT_KEY:?Set JIRA_PROJECT_KEY in the environment or .env file}"
+: "${STORY_KEY:?Set STORY_KEY in the environment or .env file}"
+: "${TEST_ISSUE_TYPE:?Set TEST_ISSUE_TYPE in the environment or .env file}"
+: "${ISSUE_LINK_TYPE:?Set ISSUE_LINK_TYPE in the environment or .env file}"
 
-
-python3 create_test_from_story.py
+python3 create_test_from_story.py "$@"


### PR DESCRIPTION
## Summary
- prevent logging the full Jira API token by masking it in create_test_from_story.py
- load configuration from a local .env file in the helper script and require required variables
- document the setup workflow and provide example env plus gitignore for secrets

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e6686bef18832788710842c74ca814